### PR TITLE
Fix return type errors.

### DIFF
--- a/src/gpm-manager.c
+++ b/src/gpm-manager.c
@@ -1238,7 +1238,7 @@ static void
 gpm_manager_engine_close_notify_cb (GpmEngine *engine, GpmManager *manager)
 {
 	if (gpm_manager_is_inhibit_valid (manager, FALSE, "policy action") == FALSE)
-		return FALSE;
+		exit(0);
 	
 	GpmSession *session;
 	// egg_debug ("logout, reason: too low battery!");

--- a/src/gpm-tray-icon.c
+++ b/src/gpm-tray-icon.c
@@ -552,6 +552,7 @@ static gpm_tray_set_theme(GtkWidget *widget, const gchar *data)
     gtk_css_provider_load_from_data(provider,data,-1,NULL);
     gtk_style_context_add_provider(context,GTK_STYLE_PROVIDER(provider),GTK_STYLE_PROVIDER_PRIORITY_USER);
     g_object_unref(provider);
+    return 0;
 }
 
 /**


### PR DESCRIPTION
Fix build on openSUSE.

> [   79s] gpm-manager.c: In function 'gpm_manager_engine_close_notify_cb':
> [   79s] /usr/include/glib-2.0/glib/gmacros.h:796:15: error: 'return' with a value, in function returning void [-Werror=return-type]
> [   79s]   796 | #define FALSE (0)
> [   79s]       |               ^
> [   79s] gpm-manager.c:1241:10: note: in expansion of macro 'FALSE'
> [   79s]  1241 |   return FALSE;
> [   79s]       |          ^~~~~
> [   79s] gpm-manager.c:1238:1: note: declared here
> [   79s]  1238 | gpm_manager_engine_close_notify_cb (GpmEngine *engine, GpmManager *manager)
> [   79s]       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> [   79s] gpm-manager.c: In function 'gpm_manager_engine_charge_critical_notify_cb':
> [   79s] gpm-manager.c:1641:25: warning: unused variable 'policy' [-Wunused-variable]
> [   80s]  1641 |         GpmActionPolicy policy;
> [   80s]       |                         ^~~~~~
> [   80s] gpm-manager.c: In function 'gpm_manager_init':
> [   80s] gpm-manager.c:2046:10: warning: unused variable 'error' [-Wunused-variable]
> [   80s]  2046 |  GError *error = NULL;
> [   80s]       |          ^~~~~
> [   80s] cc1: some warnings being treated as errors
> ```